### PR TITLE
vendor gems

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ inherit_from:
 AllCops:
   TargetRubyVersion: 2.6.6
   Exclude:
+    - 'vendor/**/*'
     - 'tmp/**/*'
     - 'bin/**/*'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ WORKDIR /app
 
 COPY Gemfile Gemfile.lock /app/
 RUN gem install bundler
+RUN bundle config set path vendor/bundle
 RUN bundle install
 
 COPY . /app/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,10 @@ services:
       REDIS_PASSWORD: ${REDIS_PASSWORD}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+    command: |
+      /bin/bash -c 
+      "bundle check || bundle install && 
+      /app/entrypoint.sh"
     build: 
       context: .
     volumes:


### PR DESCRIPTION
Allows gems to be persisted in a docker volume. we can cache them in CI to hopefully speed up build times as another PR