### PR TITLE
Disable servlet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV LANG=C.UTF-8
 RUN apt-get update && \
   apt-get upgrade -y && \
   apt-get install --no-install-recommends clamav clamdscan clamav-daemon libstdc++6 libffi-dev wget libpng-dev make curl unzip \
-  tomcat9 libmediainfo-dev openjdk-11-jre-headless -y && \
+  libmediainfo-dev openjdk-11-jre-headless -y && \
   rm -rf /var/lib/apt/lists/*
 
 RUN curl -Lo /tmp/envconsul.zip https://releases.hashicorp.com/envconsul/0.9.2/envconsul_0.9.2_linux_amd64.zip && \
@@ -32,20 +32,8 @@ RUN curl -Lo /tmp/fits.zip https://github.com/harvard-lts/fits/releases/download
   && unzip /tmp/fits.zip -d /usr/share/fits \
   && rm -rf /tmp/fits.zip
 
-RUN mkdir /usr/share/tomcat9/conf \
-  && ln -s /etc/tomcat9/catalina.properties /usr/share/tomcat9/conf/ \
-  && ln -s /etc/tomcat9/tomcat-users.xml /usr/share/tomcat9/conf/ \
-  && ln -s /etc/tomcat9/server.xml /usr/share/tomcat9/conf/
 
-RUN echo 'fits.home=/usr/share/fits' >> /usr/share/tomcat9/conf/catalina.properties \
-  && echo 'shared.loader=${fits.home}/lib/*.jar' >> /usr/share/tomcat9/conf/catalina.properties \
-  && mkdir /usr/share/tomcat9/webapps \
-  && mkdir /usr/share/tomcat9/logs \
-  && curl -Lo /usr/share/tomcat9/webapps/fits.war https://projects.iq.harvard.edu/files/fits/files/fits-1.2.1.war
-
-RUN chown -R clamav /usr/share/tomcat9 \
-  && chown -R clamav /etc/tomcat9 \
-  && mkdir /app && chown -R clamav /app
+RUN mkdir /app && chown -R clamav /app
 
 WORKDIR /app
 USER clamav

--- a/bin/rspec-ci
+++ b/bin/rspec-ci
@@ -5,15 +5,6 @@ REPORTER_BIN="cc-test-reporter"
 GIT_COMMITED_AT=$(git log -1 --date=short --pretty=format:%ct)
 export GIT_COMMITED_AT
 
-pgrep java || /usr/share/tomcat9/bin/startup.sh
-
-echo "Waiting for fits to become available"
-if ! timeout 60 bash -c 'until curl http://localhost:8080/fits/version; do sleep 1; done'
-then
-  echo "fits never became ready. Exiting"
-  exit 1
-fi
-
 if [ ! -f ${REPORTER_BIN} ]; then
   echo "Downloading Code Climate reporting tool"
   if [[ `uname` == *"Darwin"* ]]; then

--- a/lib/metadata_listener/fits_service.rb
+++ b/lib/metadata_listener/fits_service.rb
@@ -13,7 +13,7 @@ module MetadataListener
     def self.call(path)
       return {} unless Pathname.new(path).exist?
 
-      stdout, stderr, status = Open3.capture3("#{ENV.fetch("FITS_PATH", "/usr/share/fits/fits.sh")} -i #{path}" )
+      stdout, stderr, status = Open3.capture3("#{ENV.fetch('FITS_PATH', '/usr/share/fits/fits.sh')} -i #{path}")
       raise FitsError, stderr unless status.success?
 
       Hash.from_xml(stdout.to_s)

--- a/lib/metadata_listener/fits_service.rb
+++ b/lib/metadata_listener/fits_service.rb
@@ -2,6 +2,7 @@
 
 require 'http'
 require 'nokogiri'
+require 'open3'
 
 module MetadataListener
   class FitsService
@@ -12,11 +13,10 @@ module MetadataListener
     def self.call(path)
       return {} unless Pathname.new(path).exist?
 
-      endpoint = ENV.fetch('FITS_ENDPOINT', 'http://localhost:8080/fits/examine')
-      resp = HTTP.get(endpoint, params: { file: path })
-      raise FitsError, Nokogiri::HTML.parse(resp.body.to_s).title unless resp.status < 300
+      stdout, stderr, status = Open3.capture3("#{ENV.fetch("FITS_PATH", "/usr/share/fits/fits.sh")} -i #{path}" )
+      raise FitsError, stderr unless status.success?
 
-      Hash.from_xml(resp.body.to_s)
+      Hash.from_xml(stdout.to_s)
     end
   end
 end

--- a/spec/lib/metadata_listener/fits_service_spec.rb
+++ b/spec/lib/metadata_listener/fits_service_spec.rb
@@ -37,13 +37,13 @@ RSpec.describe MetadataListener::FitsService do
     end
   end
 
-  context 'with errors during the HTTP request' do
-    before { ENV['FITS_ENDPOINT'] = 'http://localhost:8080/fits/wrong' }
+  context 'with errors during the FITs call' do
+    before { ENV['FITS_PATH'] = '/usr/share/fits/fits.broken' }
 
-    after { ENV['FITS_ENDPOINT'] = 'http://localhost:8080/fits/examine' }
+    after { ENV['FITS_PATH'] = '/usr/share/fits/fits.sh' }
 
     it 'raises an error' do
-      expect { service }.to raise_error(StandardError, 'HTTP Status 404 – Not Found')
+      expect { service }.to raise_error(StandardError)
     end
   end
 

--- a/start.sh
+++ b/start.sh
@@ -1,13 +1,4 @@
 #!/bin/bash
-# TODO log to stdout somehow
-pgrep java || /usr/share/tomcat9/bin/startup.sh
-
-echo "Waiting for fits to become available"
-if ! timeout 60 bash -c 'until curl http://localhost:8080/fits/version; do sleep 1; done'
-then
-  echo "fits never became ready. Exiting"
-  exit 1
-fi
 
 echo "Starting Sidekiq"
 bin/sidekiq -C config/sidekiq.yml -r ./sidekiq.rb -vv


### PR DESCRIPTION
- removes tomcat, and the fits servlet. 
- refactors the fits job to shell out the `fits.sh` command instead of using the servlet. 
- a 178MB dmg completed in 20925.57ms
- removed unused tests