### PR TITLE
Call Clamby::Command directly

### DIFF
--- a/lib/metadata_listener/clamav_service.rb
+++ b/lib/metadata_listener/clamav_service.rb
@@ -5,11 +5,22 @@ require 'clamby'
 module MetadataListener
   class ClamavService
     # @param [String] path of file to scan
+    # @note This duplicates Clamby::Command with some changes so that instances where the executeable returns nil or 2
+    # do not result in false positives.
     def self.call(path)
       return false unless Pathname.new(path).exist?
 
-      Clamby.configure(daemonize: false)
-      Clamby.virus?(path)
+      Clamby::Command.new.run 'clamscan', path, '--no-summary'
+
+      # $CHILD_STATUS maybe nil if the execution itself (not the client process) fails
+      case $CHILD_STATUS&.exitstatus
+      when 0
+        false
+      when 1
+        true
+      else
+        raise Clamby::ClamscanClientError.new('Clamscan client error')
+      end
     end
   end
 end

--- a/spec/lib/metadata_listener/clamav_service_spec.rb
+++ b/spec/lib/metadata_listener/clamav_service_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe MetadataListener::ClamavService do
-  subject { described_class.call(path) }
+  subject(:service) { described_class.call(path) }
 
   context 'when a virus is not present' do
     let(:path) { fixture_path.join('1.pdf').to_s }
@@ -19,5 +19,19 @@ RSpec.describe MetadataListener::ClamavService do
     let(:path) { 'nothere' }
 
     it { is_expected.to be(false) }
+  end
+
+  context 'when clamscan returns a different exit code' do
+    let(:path) { fixture_path.join('1.pdf').to_s }
+    let(:mock_command) { instance_spy('Clamby::Command') }
+
+    before do
+      allow(Clamby::Command).to receive(:new).and_return(mock_command)
+      allow(mock_command).to receive(:run) { system('exit 2', out: File::NULL) }
+    end
+
+    it 'raises an error' do
+      expect { service }.to raise_error(Clamby::ClamscanClientError)
+    end
   end
 end


### PR DESCRIPTION
Because the Clamby gem is supporting legacy behavior, if clamscan encounters an unknown error, Clamby will indicate that the file has a virus, when in fact, it may not. This is a false-positive case, and the legacy behavior takes a slightly paranoid approach. While this is understandable, it creates problems on our end, and we'd rather know that file caused an error when scanned and not that it "has a virus."

To get around this, we're calling the same methods that the gem does and handling the errors in our own way. An exit code of 0 means "no virus", an exit code of 1 means "definitely virus", and anything else raises an error and we figure it out later, re-try, etc.

According to the man pages (https://linux.die.net/man/1/clamscan) the only exit codes are 0, 1, and 2. So this should cover things.

Fixes #44 