### PR TITLE
Tika text should only be UTF-8

### DIFF
--- a/lib/metadata_listener/report/extracted_text.rb
+++ b/lib/metadata_listener/report/extracted_text.rb
@@ -65,6 +65,7 @@ module MetadataListener
         def text_file
           @text_file ||= begin
                            file = Tempfile.new(['', '.txt'])
+                           file.binmode
                            file.write(Service::Tika.new(path).text)
                            file.close
                            Pathname.new(file)

--- a/lib/metadata_listener/service/tika.rb
+++ b/lib/metadata_listener/service/tika.rb
@@ -13,7 +13,10 @@ module MetadataListener
       end
 
       def text
-        @text ||= rta.to_text.gsub(/\n+/, ' ')
+        return cleaned_text if cleaned_text.encoding.name == 'UTF-8'
+
+        MetadataListener.logger.warn('Text is not UTF-8 and cannot be used')
+        ''
       end
 
       def metadata
@@ -21,6 +24,10 @@ module MetadataListener
       end
 
       private
+
+        def cleaned_text
+          @cleaned_text ||= rta.to_text.gsub(/\n+/, ' ')
+        end
 
         def elements
           @elements ||= rta.to_metadata.split("\n")

--- a/spec/lib/metadata_listener/service/tika_spec.rb
+++ b/spec/lib/metadata_listener/service/tika_spec.rb
@@ -30,4 +30,25 @@ RSpec.describe MetadataListener::Service::Tika do
     its(:text) { is_expected.to eq('') }
     its(:metadata) { is_expected.to include('Content-Type' => 'image/png') }
   end
+
+  context 'with a non UTF-8 document' do
+    let(:mock_tika) { instance_spy('RubyTikaApp') }
+    let(:mock_logger) { instance_spy('Logger') }
+
+    before do
+      allow(RubyTikaApp).to receive(:new).and_return(mock_tika)
+      allow(MetadataListener).to receive(:logger).and_return(mock_logger)
+
+      # Mock RubyTikaApp to return some funky binary ASCII-8BIT text data. We're not sure if Tika will ever _actually_
+      # do this, but if it does, we don't want to send it along to Scholarpshere becuase it's assuming that all
+      # extracted text coming from this app is UTF-8
+      allow(mock_tika).to receive(:to_text).and_return("Hello \x93\xfa\x96\x7b".b)
+    end
+
+    it 'logs a message' do
+      service = described_class.new('path')
+      expect(service.text).to eq('')
+      expect(mock_logger).to have_received(:warn).with('Text is not UTF-8 and cannot be used')
+    end
+  end
 end


### PR DESCRIPTION
As a corollary to https://github.com/psu-libraries/scholarsphere/pull/1063, Scholarsphere assumes any extracted text from this app is UTF-8. If, for some reason, Tika doesn't give us UTF-8, we won't return it and leave a message.

Related to https://github.com/psu-libraries/scholarsphere/issues/1055