### PR TITLE
Adds 30 minute timeout to listener

### DIFF
--- a/lib/metadata_listener/job.rb
+++ b/lib/metadata_listener/job.rb
@@ -21,7 +21,7 @@ module MetadataListener
 
         FileUtils.rm_f(file.body.path)
       end
-    rescue Timeout => e
+    rescue Timeout::Error => e
       Bugsnag.notify("MetadataListener timed out. SideKiq jid: #{jid}")
       raise e
     end

--- a/lib/metadata_listener/job.rb
+++ b/lib/metadata_listener/job.rb
@@ -4,6 +4,7 @@ require 'active_job'
 
 module MetadataListener
   class Job < ActiveJob::Base
+    include Sidekiq::Worker
     queue_as :metadata
     sidekiq_options timeout: 1800
 

--- a/lib/metadata_listener/job.rb
+++ b/lib/metadata_listener/job.rb
@@ -5,13 +5,14 @@ require 'active_job'
 module MetadataListener
   class Job < ActiveJob::Base
     queue_as :metadata
+    TIMEOUT = 1800
 
     # @param [String] path indicating where the file is stored in S3
     # @param [String] endpoint to send results to
     # @param [String] api_token used to authenticate with endpoint
     # @param [Array<Symbol>] reporting services to run, defaults to []
     def perform(path:, endpoint: nil, api_token: nil, services: [])
-      Timeout.timeout(1800) do
+      Timeout.timeout(TIMEOUT) do
         file = MetadataListener.s3_client.download_file(path)
         services << :virus if services.empty?
 

--- a/lib/metadata_listener/job.rb
+++ b/lib/metadata_listener/job.rb
@@ -21,9 +21,9 @@ module MetadataListener
 
         FileUtils.rm_f(file.body.path)
       end
-    rescue
-      Bugsnag.notify("MetadataListener timed out.  SideKiq jid: #{jid}")
-      raise
+    rescue Timeout => e
+      Bugsnag.notify("MetadataListener timed out. SideKiq jid: #{jid}")
+      raise e
     end
 
     private

--- a/lib/metadata_listener/job.rb
+++ b/lib/metadata_listener/job.rb
@@ -5,6 +5,7 @@ require 'active_job'
 module MetadataListener
   class Job < ActiveJob::Base
     queue_as :metadata
+    sidekiq_options timeout: 1800
 
     # @param [String] path indicating where the file is stored in S3
     # @param [String] endpoint to send results to

--- a/spec/lib/metadata_listener/job_spec.rb
+++ b/spec/lib/metadata_listener/job_spec.rb
@@ -33,4 +33,15 @@ RSpec.describe MetadataListener::Job do
       )
     end
   end
+
+  context 'when the job reaches timeout' do
+    before do
+      allow(MetadataListener::Report::Virus).to receive(:call).and_return(sleep(10))
+    end
+
+    it 'raises Timeout::Error' do
+      stup_const('MetadataListener::Job::TIMEOUT', 3)
+      expect { described_class.perform_now(path:) }.to raise_error(Timeout::Error)
+    end
+  end
 end

--- a/spec/lib/metadata_listener/job_spec.rb
+++ b/spec/lib/metadata_listener/job_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe MetadataListener::Job do
     end
 
     it 'raises Timeout::Error' do
-      stup_const('MetadataListener::Job::TIMEOUT', 3)
+      stub_const('MetadataListener::Job::TIMEOUT', 3)
       expect { described_class.perform_now(path:) }.to raise_error(Timeout::Error)
     end
   end


### PR DESCRIPTION
We've got a listener process that appears to be stalled with no indication of what's causing it.  This is my temporary solution to get past the stall so the processes that work can run.  It appears to be an issue with the file, but I cannot pinpoint what.  I can adjust the timeout if needed.

Also, this will just send the process over to the SideKiq dead queue, so we'll still be failing healthchecks.  But we can troubleshoot from there while the rest of the processes can run.